### PR TITLE
Fixes for test stability issues (#227)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ matrix:
           env: PYVERSION='2.7.13'
         - os: osx
           language: generic
-          env: PYVERSION='3.4.0'
+          env: PYVERSION='3.4.7'
         - os: osx
           language: generic
-          env: PYVERSION='3.5.0'
+          env: PYVERSION='3.5.4'
         - os: osx
           language: generic
           env: PYVERSION='3.6.0'
@@ -44,7 +44,7 @@ before_install:
 install:
 - python setup.py install
 script:
-- if [ "$TRAVIS_OS_NAME" == "osx" ]; then travis_wait 30 coverage run --source=spiceypy setup.py test; else coverage run --source=spiceypy setup.py test; fi
+- coverage run --source=spiceypy setup.py test
 after_success:
 - coveralls
 deploy:

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -1662,12 +1662,12 @@ def test_dskw02_dskrb2_dskmi2():
     first = -50 * spice.jyear()
     last  =  50 * spice.jyear()
     # stuff from spicedsk.h
-    SPICE_DSK02_MAXVRT = 16000002 // 4 # divide to lower memory usage
+    SPICE_DSK02_MAXVRT = 16000002 // 128 # divide to lower memory usage
     SPICE_DSK02_MAXPLT = 2 * (SPICE_DSK02_MAXVRT - 2)
     SPICE_DSK02_MAXVXP = SPICE_DSK02_MAXPLT // 2
-    SPICE_DSK02_MAXCEL = 60000000 // 4 # divide to lower memory usage
+    SPICE_DSK02_MAXCEL = 60000000 // 128 # divide to lower memory usage
     SPICE_DSK02_MXNVLS = SPICE_DSK02_MAXCEL + (SPICE_DSK02_MAXVXP // 2)
-    SPICE_DSK02_MAXCGR = 100000   // 4 # divide to lower memory usage
+    SPICE_DSK02_MAXCGR = 100000   // 128 # divide to lower memory usage
     SPICE_DSK02_IXIFIX = SPICE_DSK02_MAXCGR + 7
     SPICE_DSK02_MAXNPV = 3 * (SPICE_DSK02_MAXPLT // 2) + 1
     SPICE_DSK02_SPAISZ = SPICE_DSK02_IXIFIX + SPICE_DSK02_MAXVXP + SPICE_DSK02_MXNVLS + SPICE_DSK02_MAXVRT + SPICE_DSK02_MAXNPV
@@ -1978,10 +1978,9 @@ def test_ekacec():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "test_table_ekacec", 1, 10, ["c1"], 200,
-                         ["DATATYPE = CHARACTER*(*), NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "test_table_ekacec", ["c1"], ["DATATYPE = CHARACTER*(*), NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
-    spice.ekacec(handle, segno, recno, "c1", 2, 10, ["1.0", "2.0"], False)
+    spice.ekacec(handle, segno, recno, "c1", 2, ["1.0", "2.0"], False)
     spice.ekcls(handle)
     spice.kclear()
     if spice.exists(ekpath):
@@ -1995,8 +1994,7 @@ def test_ekaced():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "test_table_ekaced", 1, 10, ["c1"], 200,
-                         ["DATATYPE = DOUBLE PRECISION, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "test_table_ekaced", ["c1"], ["DATATYPE = DOUBLE PRECISION, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekaced(handle, segno, recno, "c1", 2, [1.0, 2.0], False)
     spice.ekcls(handle)
@@ -2014,40 +2012,38 @@ def test_ekmany():
         os.remove(ekpath) # pragma: no cover
     # Create new EK and new segment with table
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, tablename, 3, 10, "c1 d1 i1".split(), 200,
-                         ["DATATYPE = CHARACTER*(10),   NULLS_OK = FALSE, SIZE = VARIABLE",
-                          "DATATYPE = DOUBLE PRECISION, NULLS_OK = FALSE, SIZE = VARIABLE",
-                          "DATATYPE = INTEGER,          NULLS_OK = FALSE, SIZE = VARIABLE"]
-                        )
-    # Use EKINSR to insert two records at recno 0, one at recno 2
-    # - First inserted record will become final record 1
-    for insertrecno, finalrecno in ((0, 1), (0, 0), (2, 2)):
-        assert None is spice.ekinsr(handle, segno, insertrecno)
-        assert not spice.failed()
-        # Insert records:  1, 2, and 3 entries at rows 0, 1, 2, respectively
-        # - Integer values are final record number + 100
-        iBaseVals = [100+finalrecno]*(finalrecno+1)
-        # List-ify map to ensure listToCharArrayPtr sees list, not map object
-        spice.ekacec(handle, segno, insertrecno, "c1", finalrecno+1, 11, list(map(str, iBaseVals)),   False)
-        spice.ekaced(handle, segno, insertrecno, "d1", finalrecno+1,     list(map(float, iBaseVals)), False)
-        spice.ekacei(handle, segno, insertrecno, "i1", finalrecno+1,     iBaseVals,                   False)
-        assert not spice.failed()
+    decls = ["DATATYPE = CHARACTER*(10),   NULLS_OK = FALSE, SIZE = VARIABLE",
+             "DATATYPE = DOUBLE PRECISION, NULLS_OK = FALSE, SIZE = VARIABLE",
+             "DATATYPE = INTEGER,          NULLS_OK = FALSE, SIZE = VARIABLE"]
+    segno = spice.ekbseg(handle, tablename, ['c1', 'd1', 'i1'], decls)
+    # Insert records:  1, 2, and 3 entries at rows 0, 1, 2, respectively
+    c_data = [['100'], ['101', '101'], ['102', '102', '102']]
+    d_data = [[100.0], [101.0, 101.0], [102.0, 102.0, 102.0]]
+    i_data = [[100], [101, 101], [102, 102, 102]]
+    for r in range(0, 3):
+        spice.ekinsr(handle, segno, r)
+        spice.ekacec(handle, segno, r, "c1", len(c_data[r]), c_data[r], False)
+        spice.ekaced(handle, segno, r, "d1", len(d_data[r]), d_data[r], False)
+        spice.ekacei(handle, segno, r, "i1", len(i_data[r]), i_data[r], False)
     # Try record insertion beyond the next available, verify the exception
     with pytest.raises(spice.stypes.SpiceyError):
         spice.ekinsr(handle, segno, 4)
     # Close EK, then reopen for reading
     spice.ekcls(handle)
     spice.kclear()
+    #
+    # Start of part two
+    #
     handle = spice.eklef(ekpath)
     assert handle is not None
     # Test query using ekpsel
     query = "SELECT c1, d1, i1 from {}".format(tablename)
     n, xbegs, xends, xtypes, xclass, tabs, cols, err, errmsg = spice.ekpsel(query, 99, 99, 99)
-    assert 3 == n
-    assert dict(spice.stypes.SpiceEKDataType._fields_)['SPICE_CHR'].value == xtypes[0]
-    assert dict(spice.stypes.SpiceEKDataType._fields_)['SPICE_DP'].value == xtypes[1]
-    assert dict(spice.stypes.SpiceEKDataType._fields_)['SPICE_INT'].value == xtypes[2]
-    assert ([dict(spice.stypes.SpiceEKExprClass._fields_)['SPICE_EK_EXP_COL'].value]*3) == list(xclass)
+    assert n == 3
+    assert spice.stypes.SpiceEKDataType.SPICE_CHR == xtypes[0]
+    assert spice.stypes.SpiceEKDataType.SPICE_DP  == xtypes[1]
+    assert spice.stypes.SpiceEKDataType.SPICE_INT == xtypes[2]
+    assert ([spice.stypes.SpiceEKExprClass.SPICE_EK_EXP_COL]*3) == list(xclass)
     assert (["TEST_TABLE_EKMANY"]*3) == tabs
     assert "C1 D1 I1".split() == cols
     assert not err
@@ -2057,102 +2053,90 @@ def test_ekmany():
     assert nmrows == 3
     assert not error
     assert '' == errmsg
+    # test fail case for eknelt
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.eknelt(0, nmrows+1)
     # Validate the content of each field, including exceptions when
-    saveCData = []
-    saveDData = []
-    saveIData = []
     # Loop over rows, test .ekgc/.ekgd/.ekgi
-    for recno in range(nmrows+1):
-        # Confirm number of elements in each row
-        if recno == nmrows:
-            with pytest.raises(spice.stypes.SpiceyError):
-                spice.eknelt(0, recno)
-        else:
-            assert (recno+1) == spice.eknelt(0, recno)
-        # Confirm the elements' values
-        saveCData.append([])
-        saveDData.append([])
-        saveIData.append([])
-        for iElement in range(recno+2):
-            if iElement > recno or recno == nmrows:
-                with pytest.raises(spice.stypes.SpiceyError):
-                    spice.ekgc(0, recno, iElement, lenout=11)
-                if spice.failed(): spice.reset()
-                with pytest.raises(spice.stypes.SpiceyError):
-                    spice.ekgd(1, recno, iElement)
-                if spice.failed(): spice.reset()
-                with pytest.raises(spice.stypes.SpiceyError):
-                    spice.ekgi(2, recno, iElement)
-                if spice.failed(): spice.reset()
-            else:
-                cData, iNull = spice.ekgc(0, recno, iElement, lenout=11)
-                assert cData == str(100+recno)
-                assert iNull == False
-                saveCData[-1].append(cData)
-                dData, iNull = spice.ekgd(1, recno, iElement)
-                assert dData == (100.+recno)
-                assert iNull == False
-                saveDData[-1].append(dData)
-                iData, iNull = spice.ekgi(2, recno, iElement)
-                assert iData == (100+recno)
-                assert iNull == False
-                saveIData[-1].append(iData)
+    for r in range(nmrows):
+        # get number of elements in this row
+        n_elm = spice.eknelt(0, r)
+        assert  n_elm == r + 1
+        for e in range(0, n_elm):
+            # get row int data
+            i_datum, i_null = spice.ekgi(2, r, e)
+            assert not i_null
+            assert i_datum == i_data[r][e]
+            # get row double data
+            d_datum, d_null = spice.ekgd(1, r, e)
+            assert not d_null
+            assert d_datum == d_data[r][e]
+            # get row char data
+            c_datum, c_null = spice.ekgc(0, r, e)
+            assert not c_null
+            assert c_datum == c_data[r][e]
     # Loop over rows, test .ekrcec/.ekrced/.ekrcei
-    for recno in range(nmrows+1):
-        if recno == nmrows:
-            #with pytest.raises(spice.stypes.SpiceyError):
-            #    spice.ekrcec(handle, segno, recno, "c1", 20, nelts=2222)
-            #if spice.failed(): spice.reset()
-            with pytest.raises(spice.stypes.SpiceyError):
-                spice.ekrced(handle, segno, recno, "d1")
-            if spice.failed(): spice.reset()
-            with pytest.raises(spice.stypes.SpiceyError):
-                spice.ekrcei(handle, segno, recno, "i1")
-            if spice.failed(): spice.reset()
-        else:
-            nvals, altCData, isNull = spice.ekrcec(handle, segno, recno, "c1", 11, nelts=len(saveCData[recno]))
-            assert (recno+1) == nvals
-            assert list(altCData) == saveCData[recno]
-            nvals, altDData, isNull = spice.ekrced(handle, segno, recno, "d1", nelts=len(saveDData[recno]))
-            assert (recno+1) == nvals
-            assert list(altDData) == saveDData[recno]
-            nvals, altIData, isNull = spice.ekrcei(handle, segno, recno, "i1", nelts=len(saveIData[recno]))
-            assert (recno+1) == nvals
-            assert list(altIData) == saveIData[recno]
+    for r in range(nmrows):
+        # get row int data
+        ni_vals, ri_data, i_null = spice.ekrcei(handle, segno, r, "i1")
+        assert not i_null
+        assert ni_vals == r + 1
+        npt.assert_array_equal(ri_data, i_data[r])
+        # get row double data
+        nd_vals, rd_data, d_null = spice.ekrced(handle, segno, r, "d1")
+        assert not d_null
+        assert nd_vals == r + 1
+        npt.assert_array_equal(rd_data, d_data[r])
+        # get row char data
+        nc_vals, rc_data, c_null = spice.ekrcec(handle, segno, r, "c1", 11)
+        assert not c_null
+        assert nc_vals == r + 1
+        assert rc_data == c_data[r]
+    # test out of bounds
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.ekrcei(handle, segno, 3, "i1")
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.ekrced(handle, segno, 3, "d1")
+    #with pytest.raises(spice.stypes.SpiceyError): TODO: FIX
+    #    spice.ekrcec(handle, segno, 4, "c1", 4) # this causes a SIGSEGV
+    #
+    # Part 3
+    #
     # Close file, re-open for writing
     spice.ekuef(handle)
     handle = spice.ekopw(ekpath)
     # Loop over rows, update values using .ekucec/.ekuced/.ekucei
-    for recno in range(nmrows+1):
-        iBaseVals = [200+recno]*(recno+1)
-        if recno == nmrows:
-            #with pytest.raises(spice.stypes.SpiceyError):
-            #    spice.ekucec(handle, segno, recno, "c1", recno+1, 11, list(map(str, iBaseVals)), False)
-            #if spice.failed(): spice.reset()
-            with pytest.raises(spice.stypes.SpiceyError):
-                spice.ekuced(handle, segno, recno, "d1", recno+1, list(map(float, iBaseVals)), False)
-            if spice.failed(): spice.reset()
-            with pytest.raises(spice.stypes.SpiceyError):
-                spice.ekucei(handle, segno, recno, "i1", recno+1, iBaseVals, False)
-            if spice.failed(): spice.reset()
-        else:
-            # List-ify map to ensure listToCharArrayPtr sees list, not map object
-            spice.ekucec(handle, segno, recno, "c1", recno+1, 11, list(map(str, iBaseVals)), False)
-            spice.ekuced(handle, segno, recno, "d1", recno+1, list(map(float, iBaseVals)), False)
-            spice.ekucei(handle, segno, recno, "i1", recno+1, iBaseVals, False)
-            assert not spice.failed()
+    c_data = [['200'], ['201', '201'], ['202', '202', '202']]
+    d_data = [[200.0], [201.0, 201.0], [202.0, 202.0, 202.0]]
+    i_data = [[200], [201, 201], [202, 202, 202]]
+    for r in range(0, 3):
+        spice.ekucec(handle, segno, r, "c1", len(c_data[r]), c_data[r], False)
+        spice.ekuced(handle, segno, r, "d1", len(d_data[r]), d_data[r], False)
+        spice.ekucei(handle, segno, r, "i1", len(i_data[r]), i_data[r], False)
+    # Test invalid updates
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.ekucec(handle, segno, 3, "c1", 1, ['300'], False)
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.ekuced(handle, segno, 3, "d1", 1, [300.0], False)
+    with pytest.raises(spice.stypes.SpiceyError):
+        spice.ekucei(handle, segno, 3, "i1", 1, [300], False)
     # Loop over rows, use .ekrcec/.ekrced/.ekrcei to test updates
-    for recno in range(nmrows):
-        iBaseVals = [200+recno]*(recno+1)
-        nvals, altCData, isNull = spice.ekrcec(handle, segno, recno, "c1", 11, nelts=len(saveCData[recno]))
-        assert (recno+1) == nvals
-        assert list(altCData) == list(map(str, iBaseVals))
-        nvals, altDData, isNull = spice.ekrced(handle, segno, recno, "d1", nelts=len(saveDData[recno]))
-        assert (recno+1) == nvals
-        assert list(altDData) == iBaseVals
-        nvals, altIData, isNull = spice.ekrcei(handle, segno, recno, "i1", nelts=len(saveIData[recno]))
-        assert (recno+1) == nvals
-        assert list(altIData) == list(map(float, iBaseVals))
+    for r in range(nmrows):
+        # get row int data
+        ni_vals, ri_data, i_null = spice.ekrcei(handle, segno, r, "i1")
+        assert not i_null
+        assert ni_vals == r + 1
+        npt.assert_array_equal(ri_data, i_data[r])
+        # get row double data
+        nd_vals, rd_data, d_null = spice.ekrced(handle, segno, r, "d1")
+        assert not d_null
+        assert nd_vals == r + 1
+        npt.assert_array_equal(rd_data, d_data[r])
+        # get row char data
+        nc_vals, rc_data, c_null = spice.ekrcec(handle, segno, r, "c1", 11)
+        assert not c_null
+        assert nc_vals == r + 1
+        assert rc_data == c_data[r]
     # Cleanup
     spice.ekcls(handle)
     assert not spice.failed()
@@ -2222,8 +2206,7 @@ def test_ekappr():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "test_table_ekappr", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "test_table_ekappr", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)
@@ -2241,7 +2224,7 @@ def test_ekbseg():
     handle = spice.ekopn(ekpath, "Test EK", 100)
     cnames = ['INT_COL_1']
     cdecls = ["DATATYPE=INTEGER, INDEXED=TRUE, NULLS_OK=TRUE"]
-    segno = spice.ekbseg(handle, "SCALAR_DATA", 1, 100, cnames, 200, cdecls)
+    segno = spice.ekbseg(handle, "SCALAR_DATA", cnames, cdecls)
     recno = spice.ekappr(handle, segno)
     assert recno != -1
     ordids = [x for x in range(5)]
@@ -2264,8 +2247,7 @@ def test_ekccnt():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "TEST_TABLE_EKCCNT", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "TEST_TABLE_EKCCNT", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)
@@ -2286,8 +2268,7 @@ def test_ekcii():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "TEST_TABLE_EKCII", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "TEST_TABLE_EKCII", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)
@@ -2501,8 +2482,7 @@ def test_eklef():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "test_table_eklef", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "test_table_eklef", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)
@@ -2520,8 +2500,7 @@ def test_eknseg():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "TEST_TABLE_EKNSEG", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "TEST_TABLE_EKNSEG", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)
@@ -2624,8 +2603,7 @@ def test_ektnam():
     if spice.exists(ekpath):
         os.remove(ekpath) # pragma: no cover
     handle = spice.ekopn(ekpath, ekpath, 0)
-    segno = spice.ekbseg(handle, "TEST_TABLE_EKTNAM", 1, 10, ["c1"], 200,
-                         ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
+    segno = spice.ekbseg(handle, "TEST_TABLE_EKTNAM", ["c1"], ["DATATYPE  = INTEGER, NULLS_OK = TRUE"])
     recno = spice.ekappr(handle, segno)
     spice.ekacei(handle, segno, recno, "c1", 2, [1, 2], False)
     spice.ekcls(handle)

--- a/spiceypy/utils/support_types.py
+++ b/spiceypy/utils/support_types.py
@@ -109,7 +109,7 @@ def toPythonString(inString):
     elif six.PY3:
         if isinstance(inString, c_char_p):
             return toPythonString(inString.value)
-        return bytes.decode(string_at(inString)).rstrip()
+        return bytes.decode(string_at(inString), errors="ignore").rstrip()
 
 
 def emptyCharArray(xLen=None, yLen=None):
@@ -586,13 +586,26 @@ class SpiceDLADescr(Structure):
 
 
 class SpiceEKDataType(c_int):
+    _SPICE_CHR = c_int(0)
+    _SPICE_DP  = c_int(1)
+    _SPICE_INT = c_int(2)
+    _SPICE_TIME = c_int(3)
+    _SPICE_BOOL = c_int(4)
+
+
     _fields_ = [
-        ('SPICE_CHR', c_int(0)),
-        ('SPICE_DP', c_int(1)),
-        ('SPICE_INT', c_int(2)),
-        ('SPICE_TIME', c_int(3)),
-        ('SPICE_BOOL', c_int(4)),
+        ('SPICE_CHR', _SPICE_CHR),
+        ('SPICE_DP', _SPICE_DP),
+        ('SPICE_INT', _SPICE_INT),
+        ('SPICE_TIME', _SPICE_TIME),
+        ('SPICE_BOOL', _SPICE_BOOL),
     ]
+
+    SPICE_CHR =  _SPICE_CHR.value
+    SPICE_DP  =  _SPICE_DP.value
+    SPICE_INT =  _SPICE_INT.value
+    SPICE_TIME = _SPICE_TIME.value
+    SPICE_BOOL = _SPICE_BOOL.value
 
 
 def emptySpiceEKDataTypeVector(n):
@@ -603,11 +616,19 @@ def emptySpiceEKDataTypeVector(n):
 
 
 class SpiceEKExprClass(c_int):
+    _SPICE_EK_EXP_COL = c_int(0)
+    _SPICE_EK_EXP_FUNC = c_int(1)
+    _SPICE_EK_EXP_EXPR = c_int(2)
+
     _fields_ = [
-        ('SPICE_EK_EXP_COL', c_int(0)),
-        ('SPICE_EK_EXP_FUNC', c_int(1)),
-        ('SPICE_EK_EXP_EXPR', c_int(2))
+        ('SPICE_EK_EXP_COL',  _SPICE_EK_EXP_COL),
+        ('SPICE_EK_EXP_FUNC', _SPICE_EK_EXP_FUNC),
+        ('SPICE_EK_EXP_EXPR', _SPICE_EK_EXP_EXPR)
     ]
+
+    SPICE_EK_EXP_COL = _SPICE_EK_EXP_COL.value
+    SPICE_EK_EXP_FUNC = _SPICE_EK_EXP_FUNC.value
+    SPICE_EK_EXP_EXPR = _SPICE_EK_EXP_EXPR.value
 
 
 def emptySpiceEKExprClassVector(n):


### PR DESCRIPTION
* looks like test_dskw02_dskrb2_dskmi2 was my slowest test, made it faster
* bumped 3.4.0 to 3.4.7 and 3.5.0 to 3.5.4 to hopefully see ctypes warnings go away 
* fixed and simplified test_ekmany (or most of it) (trap 6 abort fixes)
* simplified ek support types